### PR TITLE
cartage 1.1: Restore create_bundle_cache.

### DIFF
--- a/Cartage.yml.rdoc
+++ b/Cartage.yml.rdoc
@@ -258,14 +258,26 @@ as cartage-remote runs SSH in a paranoid mode.
 The postbuild script that will be run on the local system. This is optional
 with no default (no post-build actions).
 
+The postbuild script will be passed the stage identifier as <tt>$1</tt>
+(valid values are +config+, +ssh_config+, +prebuild+, +remote_clone+,
++remote_build+, +cleanup+, or +finished+). If the build was interrupted with
+an error, the error message will be passed as <tt>$2</tt>.
+
 An example that posts a message to Slack is below.
 
     plugins:
       remote:
         postbuild: |
           #!/bin/bash
-          t="token=SLACK_TOKEN"
-          c="channel=%23ci"
-          d=MYDOMAIN
-          u="https://${d}.slack.com/services/hooks/slackbot?${t}&${c}"
-          curl --data "Build %<name>s-%<timestamp>s complete." ${u}
+          case ${1:-undefined} in
+            finished)
+              t="token=SLACK_TOKEN"
+              c="channel=%23ci"
+              d=MYDOMAIN
+              u="https://${d}.slack.com/services/hooks/slackbot?${t}&${c}"
+              curl --data "Build %<name>s-%<timestamp>s complete." ${u}
+              ;;
+            *)
+              : # ${1} is the stage, ${2} is the error message
+              ;;
+          esac

--- a/History.rdoc
+++ b/History.rdoc
@@ -1,3 +1,21 @@
+=== 1.1 / 2015-03-26
+
+*   1 major enhancement
+
+    *   Added a Cartage::StatusError with an exitstatus support.
+        Cartage::QuietError is now based on this.
+
+*   1 minor bugfix
+
+    *   Restored an accidentally removed method,
+        Cartage::#create_bundle_cache.
+
+*   2 documentation improvements
+
+    *   Identified postbuild script stages.
+
+    *   Improved the Slack notifier example postbuild script.
+
 === 1.0 / 2015-03-24
 
 *   1 major enhancement

--- a/cartage.gemspec
+++ b/cartage.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: cartage 1.0 ruby lib
+# stub: cartage 1.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "cartage"
-  s.version = "1.0"
+  s.version = "1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2015-03-24"
+  s.date = "2015-03-26"
   s.description = "Cartage provides a plug-in based tool to reliably create a package for a\nBundler-based Ruby application that can be used in deployment with a\nconfiguration tool like Ansible, Chef, Puppet, or Salt. The package is created\nwith its dependencies bundled in +vendor/bundle+, so it can be deployed in\nenvironments with strict access control rules and without requiring development\ntool access.\n\nCartage has learned its tricks from Heroku, Capistrano, and Hoe. From Hoe, it\nlearned to keep a manifest to control what is packaged (as well as its plug-in\nsystem). From Heroku, it learned to keep a simple ignore file. From Capistrano,\nit learned to mark the Git hashref as a file in its built package, and to\ntimestamp the packages.\n\nCartage follows a relatively simple set of steps when creating a package:\n\n1.  Copy the application files to the work area. The application\u{2019}s files are\n    specified in +Manifest.txt+ and filtered against the exclusion list\n    (+.cartignore+). If there is no +.cartignore+, try to use +.slugignore+. If\n    there is no +.slugignore+, Cartage will use a sensible default exclusion\n    list. To override the use of this exclusion list, an empty +.cartignore+\n    file must be present.\n\n2.  The Git hashref is written to the work area (as +release_hashref+) and to\n    the package staging area.\n\n3.  Files that have been modified are restored to pristine condition in the\n    work area. The source files are not touched. (This ensures that\n    +config/database.yml+, for example, will not be the version used by a\n    continuous integration system.)\n\n4.  Bundler is fetched into the work area, and the bundle is installed into the\n    work area\u{2019}s +vendor/bundle+ without the +development+ and +test+\n    environments. If a bundle cache is kept (by default, one is), the resulting\n    +vendor/bundle+ will be put into a bundle cache so that future bundle\n    installs are faster.\n\n5.  A timestamped tarball is created from the contents of the work area. It can\n    then be copied to a more permanent or accessible location.\n\nCartage is extremely opinionated about its tools and environment:\n\n* The packages are created with +tar+ and +bzip2+ using <tt>tar cfj</tt>.\n* Cartage only understands +git+, which is used for creating\n  <tt>release_hashref</tt>s, +Manifest.txt+ creation and comparison, and even\n  default application name detection (from the name of the origin remote)."
   s.email = ["aziegler@kineticcafe.com"]
   s.executables = ["cartage"]

--- a/cartage.yml.sample
+++ b/cartage.yml.sample
@@ -153,14 +153,26 @@ plugins:
 
     # The postbuild script that will be run on the local system. This is
     # optional with no default (no post-build actions).
+    #
+    # This script will be passed the stage identifier as $1 (valid values are
+    # config, ssh_config, prebuild, remote_clone, remote_build, cleanup, or
+    # finished). If the build was interrupted with an error, the error
+    # message will be passed as $2.
     # ---
     # postbuild: |
     #   #!/bin/bash
-    #   t="token=SLACK_TOKEN"
-    #   c="channel=%23ci"
-    #   d=MYDOMAIN
-    #   u="https://${d}.slack.com/services/hooks/slackbot?${t}&${c}"
-    #   curl --data "Build %<name>s-%<timestamp>s complete." ${u}
+    #   case ${1:-undefined} in
+    #     finished)
+    #       t="token=SLACK_TOKEN"
+    #       c="channel=%23ci"
+    #       d=MYDOMAIN
+    #       u="https://${d}.slack.com/services/hooks/slackbot?${t}&${c}"
+    #       curl --data "Build %<name>s-%<timestamp>s complete." ${u}
+    #       ;;
+    #     *)
+    #       : # ${1} is the stage, ${2} is the error message
+    #       ;;
+    #   esac
 
 # This must not be indented for it to work.
 <% if File.exist?('config/ansible/cartage.yml') %>
@@ -169,4 +181,3 @@ plugins:
 <% if File.exist?('config/local/cartage.yml') %>
 <%= File.read('config/local/cartage.yml') %>
 <% end %>
-


### PR DESCRIPTION
- Fixes #1.
- Also supports the KineticCafe/cartage-remote#1 fix by making it easy to provide an exit status.
- Improve the documentation of the postbuild script.
