### PR TITLE
Fix duplicate filenames in manifest while merging or rebasing

### DIFF
--- a/cartage.gemspec
+++ b/cartage.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Austin Ziegler"]
-  s.date = "2015-03-26"
+  s.date = "2015-04-23"
   s.description = "Cartage provides a plug-in based tool to reliably create a package for a\nBundler-based Ruby application that can be used in deployment with a\nconfiguration tool like Ansible, Chef, Puppet, or Salt. The package is created\nwith its dependencies bundled in +vendor/bundle+, so it can be deployed in\nenvironments with strict access control rules and without requiring development\ntool access.\n\nCartage has learned its tricks from Heroku, Capistrano, and Hoe. From Hoe, it\nlearned to keep a manifest to control what is packaged (as well as its plug-in\nsystem). From Heroku, it learned to keep a simple ignore file. From Capistrano,\nit learned to mark the Git hashref as a file in its built package, and to\ntimestamp the packages.\n\nCartage follows a relatively simple set of steps when creating a package:\n\n1.  Copy the application files to the work area. The application\u{2019}s files are\n    specified in +Manifest.txt+ and filtered against the exclusion list\n    (+.cartignore+). If there is no +.cartignore+, try to use +.slugignore+. If\n    there is no +.slugignore+, Cartage will use a sensible default exclusion\n    list. To override the use of this exclusion list, an empty +.cartignore+\n    file must be present.\n\n2.  The Git hashref is written to the work area (as +release_hashref+) and to\n    the package staging area.\n\n3.  Files that have been modified are restored to pristine condition in the\n    work area. The source files are not touched. (This ensures that\n    +config/database.yml+, for example, will not be the version used by a\n    continuous integration system.)\n\n4.  Bundler is fetched into the work area, and the bundle is installed into the\n    work area\u{2019}s +vendor/bundle+ without the +development+ and +test+\n    environments. If a bundle cache is kept (by default, one is), the resulting\n    +vendor/bundle+ will be put into a bundle cache so that future bundle\n    installs are faster.\n\n5.  A timestamped tarball is created from the contents of the work area. It can\n    then be copied to a more permanent or accessible location.\n\nCartage is extremely opinionated about its tools and environment:\n\n* The packages are created with +tar+ and +bzip2+ using <tt>tar cfj</tt>.\n* Cartage only understands +git+, which is used for creating\n  <tt>release_hashref</tt>s, +Manifest.txt+ creation and comparison, and even\n  default application name detection (from the name of the origin remote)."
   s.email = ["aziegler@kineticcafe.com"]
   s.executables = ["cartage"]
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/KineticCafe/cartage/"
   s.licenses = ["MIT"]
   s.rdoc_options = ["--main", "README.rdoc"]
-  s.rubygems_version = "2.2.2"
+  s.rubygems_version = "2.2.3"
   s.summary = "Cartage provides a plug-in based tool to reliably create a package for a Bundler-based Ruby application that can be used in deployment with a configuration tool like Ansible, Chef, Puppet, or Salt"
 
   if s.respond_to? :specification_version then
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<cmdparse>, ["~> 3.0"])
-      s.add_development_dependency(%q<minitest>, ["~> 5.5"])
+      s.add_development_dependency(%q<minitest>, ["~> 5.6"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_development_dependency(%q<rake>, ["~> 10.0"])
       s.add_development_dependency(%q<hoe-doofus>, ["~> 1.0"])
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
     else
       s.add_dependency(%q<cmdparse>, ["~> 3.0"])
-      s.add_dependency(%q<minitest>, ["~> 5.5"])
+      s.add_dependency(%q<minitest>, ["~> 5.6"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
       s.add_dependency(%q<rake>, ["~> 10.0"])
       s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<cmdparse>, ["~> 3.0"])
-    s.add_dependency(%q<minitest>, ["~> 5.5"])
+    s.add_dependency(%q<minitest>, ["~> 5.6"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
     s.add_dependency(%q<rake>, ["~> 10.0"])
     s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])

--- a/lib/cartage/manifest.rb
+++ b/lib/cartage/manifest.rb
@@ -94,6 +94,14 @@ or update the Manifest.txt file with the following command:
     ignore_file.open('w') { |f| f.puts data } if save
   end
 
+  def create_file_list(filename)
+    Pathname(filename).tap { |file|
+      file.open('w') { |f|
+        f.puts prune(%x(git ls-files).split.map(&:chomp)).sort.uniq.join("\n")
+      }
+    }
+  end
+
   private
 
   def ignore_file
@@ -106,14 +114,6 @@ or update the Manifest.txt file with the following command:
 
   def manifest_file
     @manifest_file ||= @cartage.root_path.join('Manifest.txt')
-  end
-
-  def create_file_list(filename)
-    Pathname(filename).tap { |file|
-      file.open('w') { |f|
-        f.puts prune(%x(git ls-files).split.map(&:chomp)).sort.join("\n")
-      }
-    }
   end
 
   def ignore_patterns(with_slugignore: false)

--- a/test/minitest_config.rb
+++ b/test/minitest_config.rb
@@ -57,11 +57,12 @@ module Minitest::ENVStub
 
     mfile.send(:define_method, :open, &fopen)
     yield
-    assert_equal expected, string_io.string
+    actual = String.new(string_io.string)
   ensure
     mfile.send(:undef_method, :open)
     mfile.send(:alias_method, :open, :__stub_open__)
     mfile.send(:undef_method, :__stub_open__)
+    assert_equal expected, actual
   end
 
   def stub_pathname_expand_path value, &block

--- a/test/test_cartage_manifest.rb
+++ b/test/test_cartage_manifest.rb
@@ -1,0 +1,24 @@
+require 'minitest_config'
+require 'cartage/plugin'
+require 'cartage/command'
+require 'cartage/manifest'
+
+describe Cartage::Manifest do
+  before do
+    @cartage = Cartage.new
+    @manifest = Cartage::Manifest.new(@cartage)
+  end
+
+  describe '#create_file_list' do
+    it 'only sets unique files' do
+      files = %w(a a a b c).join("\n")
+      expected = %w(a b c).join("\n") + "\n"
+
+      stub_file_open_for_write expected do
+        stub_backticks files do
+          @manifest.create_file_list 'x'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- `create_file_list` now uses `uniq` on file list
- `create_file_list` is no longer private
- Fix `stub_file_open_for_write` assertion to prevent errors on failing
  test
