### PR TITLE
Fix duplicate filenames in manifest while merging or rebasing

### DIFF
--- a/lib/cartage/manifest.rb
+++ b/lib/cartage/manifest.rb
@@ -111,7 +111,7 @@ or update the Manifest.txt file with the following command:
   def create_file_list(filename)
     Pathname(filename).tap { |file|
       file.open('w') { |f|
-        f.puts prune(%x(git ls-files).split.map(&:chomp)).sort.join("\n")
+        f.puts prune(%x(git ls-files).split.map(&:chomp)).sort.uniq.join("\n")
       }
     }
   end

--- a/lib/cartage/manifest.rb
+++ b/lib/cartage/manifest.rb
@@ -210,6 +210,8 @@ db/seeds/test/
 # db/seeds/staging/
 log/
 test/
+rspec/
+feature/
 tmp/
 vendor/bundle/
   EOM

--- a/test/minitest_config.rb
+++ b/test/minitest_config.rb
@@ -57,11 +57,12 @@ module Minitest::ENVStub
 
     mfile.send(:define_method, :open, &fopen)
     yield
-    assert_equal expected, string_io.string
+    actual = String.new(string_io.string)
   ensure
     mfile.send(:undef_method, :open)
     mfile.send(:alias_method, :open, :__stub_open__)
     mfile.send(:undef_method, :__stub_open__)
+    assert_equal expected, actual
   end
 
   def stub_pathname_expand_path value, &block

--- a/test/test_cartage_manifest.rb
+++ b/test/test_cartage_manifest.rb
@@ -1,0 +1,24 @@
+require 'minitest_config'
+require 'cartage/plugin'
+require 'cartage/command'
+require 'cartage/manifest'
+
+describe Cartage::Manifest do
+  before do
+    @cartage = Cartage.new
+    @manifest = Cartage::Manifest.new(@cartage)
+  end
+
+  describe '#create_file_list' do
+    it 'only sets unique files' do
+      files = %w(a a a b c).join("\n")
+      expected = %w(a b c).join("\n") + "\n"
+
+      stub_file_open_for_write expected do
+        stub_backticks files do
+          @manifest.send :create_file_list, 'x'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- `create_file_list` now uses `uniq` on file list
- Fix `stub_file_open_for_write` assertion to prevent errors on failing
  test
- Fix #3
