### PR TITLE
Cartage 2.1: Add local plugin discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,33 @@
+---
 language: ruby
-
 rvm:
-  - 2.3.1
-  - 2.2.5
+  - 2.4.0
+  - 2.3.3
+  - 2.2.6
   - 2.1.9
-  - 2.0
-  - jruby-9.1.0.0
+  - 2.0.0
   - jruby-9.0.5.0
+  - jruby-9.1.6.0
   - ruby-head
   - jruby-head
-
-gemfile:
-  - Gemfile
-
-bundler_args: --path vendor/bundle
-
-sudo: false
-
-before_script:
-  - bundle exec rake travis:before -t
-
-script: bundle exec rake travis
-
-after_script:
-  - bundle exec rake travis:after -t
-
-env:
-  - - RUBYOPT=-W0
-    - BUNDLE_WITHOUT=local_development
-
-before_install:
-  - bundle config --local without local_development
-
 matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
   fast_finish: true
-
+gemfile:
+  - Gemfile
+bundler_args: --path vendor/bundle
+before_script:
+  - bundle exec rake travis:before -t
+script: bundle exec rake travis
+after_script:
+  - bundle exec rake travis:after -t
+env:
+  - - RUBYOPT=-W0
+    - BUNDLE_WITHOUT=local_development
+before_install:
+  - bundle config --local without local_development
 notifications:
   email:
     on_success: change
@@ -48,3 +38,4 @@ notifications:
     notify: true
     rooms:
       secure: CbG+RlNoPO4KWPLNcrJ/5j/hjlNcQD/XSnM7ebFA1WmajZOvkfArb/4Z9rcwfLMFAvZKHM+2l4J4+natvrfgQ9aTq9dQXQeF5AEFJlbbHrD6q7neAw/ER2xpoQ1I6SwbBTW81YIKXzXjK4eA83QxDRzT14x8hOeAFlMEUfCoRoyr+X6Y/TMii9CcRSf4AIumi4C7TFMV/rvggbTjuXXk3RjS+YYe/YQmFOcinHHJMf1A2s5aoOOPPKhL0i37Do15WgvhexOCj92CDfGfLEL5bM0SuBSuFTGQX7BCaemUcS9amKJgzTeULexgfZ0YD0BRAJV7p2CEVIwrhEei1EHG/3vF6ReiFkMTJN35PSDnpzGgb8jhYpvQx9xm3x1iwTFpiWhD83Q5sC6BlEZXkH1LaU8SSgQNYcgcUKWJ2Tgkf4Y16JCW6sEruyAxg0SiZNrHJKjhpdeKHzEPcngLLXAxpBMaYiZsZm2MTU85bZodhvuBY5vcvo/BpNmPPY5k+B96yrUXsmPOgHtXls2POOVCYKRsbdjDYi0/s/KvHNPeSO+caQ8HnQVlxBs2uZRy/hryiDQWJVKX5MyvTnf7oWUmln5a2VWSXZUtokHyqnCYT9BST3IBVEKRDrP0vtcXAVBgQj1BLrdzsEEVE7w6Nxr3zRxDIH6WDn44cCMvWscXLi4=
+sudo: false

--- a/Contributing.md
+++ b/Contributing.md
@@ -51,15 +51,15 @@ Here's the most direct way to get your work merged into the project:
 
 *   Fork the project.
 *   Clone down your fork (`git clone
-    git://github.com/KineticCafe/cartage.git`).
+    git://github.com/<username>/cartage.git`).
 *   Create a topic branch to contain your change (`git checkout -b
     my_awesome_feature`).
 *   Hack away, add tests. Not necessarily in that order.
 *   Make sure everything still passes by running `rake`.
 *   If necessary, rebase your commits into logical chunks, without errors.
 *   Push the branch up (`git push origin my_awesome_feature`).
-*   Create a pull request against KineticCafe/cartage and describe
-    what your change does and the why you think it should be merged.
+*   Create a pull request against KineticCafe/cartage and describe your change
+    does and the why you think it should be merged.
 
 ### Contributors
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source 'https://rubygems.org/'
 # Specify your gem's dependencies in cartage.gemspec
 gemspec
 
-group :local_development, :test do
+group :local_development do
   gem 'cartage-s3', path: '../cartage-s3'
   gem 'cartage-bundler', path: '../cartage-bundler'
   gem 'cartage-remote', path: '../cartage-remote'

--- a/History.md
+++ b/History.md
@@ -1,3 +1,23 @@
+### 2.1 / 2017-02-18
+
+*   Cartage 2.1 now knows how to load plug-ins relative to the project root
+    path. If you have a plug-in that you aren’t ready to release as a gem, just
+    put it in your project as `<ROOT_PATH>/lib/cartage/plugins/foo.rb`; Cartage
+    will find it automatically. This feature does not work with command
+    extensions.
+
+*   The hidden command, `cartage info plugins`, will now correctly report
+    plug-in versions.
+
+*   Cartage tries to restore files that were modified by a build system prior
+    to packaging. This would fail on files that were not part of the resulting
+    tarball (because they were in .cartignore). This has been fixed.
+
+*   A new utility function, Cartage#recursive_copy has been added to
+    recursively copy directories from disk into the work path. The interaction
+    of relative and absolute directories is subtle but documented on the method
+    itself.
+
 ### 2.0 / 2016-05-31
 
 *   Rewrite! Over the last year, a number of deficiencies have been found,

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ Hoe.plugin :travis
 
 spec = Hoe.spec 'cartage' do
   developer('Austin Ziegler', 'aziegler@kineticcafe.com')
+  developer('Kinetic Cafe', 'dev@kineticcafe.com')
 
   self.history_file = 'History.md'
   self.readme_file = 'README.rdoc'
@@ -24,7 +25,7 @@ spec = Hoe.spec 'cartage' do
 
   extra_deps << ['gli', '~> 2.13']
 
-  extra_dev_deps << ['rake', '>= 10.0']
+  extra_dev_deps << ['rake', '>= 10.0', '< 12.0']
   extra_dev_deps << ['rdoc', '~> 4.2']
   extra_dev_deps << ['hoe-doofus', '~> 1.0']
   extra_dev_deps << ['hoe-gemspec2', '~> 1.1']

--- a/cartage.gemspec
+++ b/cartage.gemspec
@@ -1,80 +1,80 @@
 # -*- encoding: utf-8 -*-
-# stub: cartage 2.0 ruby lib
+# stub: cartage 2.1 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "cartage".freeze
-  s.version = "2.0"
+  s.name = "cartage"
+  s.version = "2.1"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib".freeze]
-  s.authors = ["Austin Ziegler".freeze]
-  s.date = "2016-05-31"
-  s.description = "Cartage provides a repeatable means to create a package for a server-side\napplication that can be used in deployment with a configuration tool like\nAnsible, Chef, Puppet, or Salt. The package is created with vendored\ndependencies so that it can be deployed in environments with strict access\ncontrol rules and without requiring development tool presence on the target\nserver(s).".freeze
-  s.email = ["aziegler@kineticcafe.com".freeze]
-  s.executables = ["cartage".freeze]
-  s.extra_rdoc_files = ["Cartage.yml.rdoc".freeze, "Contributing.md".freeze, "Extending.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "cartage-cli.md".freeze]
-  s.files = ["Cartage.yml.rdoc".freeze, "Contributing.md".freeze, "Extending.md".freeze, "History.md".freeze, "Licence.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "Rakefile".freeze, "bin/cartage".freeze, "cartage-cli.md".freeze, "cartage.yml.sample".freeze, "lib/cartage.rb".freeze, "lib/cartage/backport.rb".freeze, "lib/cartage/cli.rb".freeze, "lib/cartage/commands/echo.rb".freeze, "lib/cartage/commands/info.rb".freeze, "lib/cartage/commands/manifest.rb".freeze, "lib/cartage/commands/pack.rb".freeze, "lib/cartage/config.rb".freeze, "lib/cartage/core.rb".freeze, "lib/cartage/gli_ext.rb".freeze, "lib/cartage/minitest.rb".freeze, "lib/cartage/plugin.rb".freeze, "lib/cartage/plugins/build_tarball.rb".freeze, "lib/cartage/plugins/manifest.rb".freeze, "test/minitest_config.rb".freeze, "test/test_cartage.rb".freeze, "test/test_cartage_build_tarball.rb".freeze, "test/test_cartage_config.rb".freeze, "test/test_cartage_core.rb".freeze, "test/test_cartage_manifest.rb".freeze, "test/test_cartage_plugin.rb".freeze]
-  s.homepage = "https://github.com/KineticCafe/cartage/".freeze
-  s.licenses = ["MIT".freeze]
-  s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
-  s.required_ruby_version = Gem::Requirement.new("~> 2.0".freeze)
-  s.rubygems_version = "2.6.4".freeze
-  s.summary = "Cartage provides a repeatable means to create a package for a server-side application that can be used in deployment with a configuration tool like Ansible, Chef, Puppet, or Salt".freeze
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["Austin Ziegler", "Kinetic Cafe"]
+  s.date = "2017-02-18"
+  s.description = "Cartage provides a repeatable means to create a package for a server-side\napplication that can be used in deployment with a configuration tool like\nAnsible, Chef, Puppet, or Salt. The package is created with vendored\ndependencies so that it can be deployed in environments with strict access\ncontrol rules and without requiring development tool presence on the target\nserver(s)."
+  s.email = ["aziegler@kineticcafe.com", "dev@kineticcafe.com"]
+  s.executables = ["cartage"]
+  s.extra_rdoc_files = ["Cartage.yml.rdoc", "Contributing.md", "Extending.md", "History.md", "Licence.md", "Manifest.txt", "README.rdoc", "cartage-cli.md"]
+  s.files = ["Cartage.yml.rdoc", "Contributing.md", "Extending.md", "History.md", "Licence.md", "Manifest.txt", "README.rdoc", "Rakefile", "bin/cartage", "cartage-cli.md", "cartage.yml.sample", "lib/cartage.rb", "lib/cartage/backport.rb", "lib/cartage/cli.rb", "lib/cartage/commands/echo.rb", "lib/cartage/commands/info.rb", "lib/cartage/commands/manifest.rb", "lib/cartage/commands/pack.rb", "lib/cartage/config.rb", "lib/cartage/core.rb", "lib/cartage/gli_ext.rb", "lib/cartage/minitest.rb", "lib/cartage/plugin.rb", "lib/cartage/plugins/build_tarball.rb", "lib/cartage/plugins/manifest.rb", "test/minitest_config.rb", "test/test_cartage.rb", "test/test_cartage_build_tarball.rb", "test/test_cartage_config.rb", "test/test_cartage_core.rb", "test/test_cartage_manifest.rb", "test/test_cartage_plugin.rb"]
+  s.homepage = "https://github.com/KineticCafe/cartage/"
+  s.licenses = ["MIT"]
+  s.rdoc_options = ["--main", "README.rdoc"]
+  s.required_ruby_version = Gem::Requirement.new("~> 2.0")
+  s.rubygems_version = "2.5.1"
+  s.summary = "Cartage provides a repeatable means to create a package for a server-side application that can be used in deployment with a configuration tool like Ansible, Chef, Puppet, or Salt"
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<gli>.freeze, ["~> 2.13"])
-      s.add_development_dependency(%q<minitest>.freeze, ["~> 5.9"])
-      s.add_development_dependency(%q<rdoc>.freeze, ["~> 4.0"])
-      s.add_development_dependency(%q<rake>.freeze, [">= 10.0"])
-      s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-      s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-      s.add_development_dependency(%q<hoe-git>.freeze, ["~> 1.5"])
-      s.add_development_dependency(%q<hoe-travis>.freeze, ["~> 1.2"])
-      s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-      s.add_development_dependency(%q<minitest-bisect>.freeze, ["~> 1.2"])
-      s.add_development_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 2.0"])
-      s.add_development_dependency(%q<minitest-focus>.freeze, ["~> 1.1"])
-      s.add_development_dependency(%q<minitest-moar>.freeze, ["~> 0.0"])
-      s.add_development_dependency(%q<minitest-pretty_diff>.freeze, ["~> 0.1"])
-      s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.7"])
-      s.add_development_dependency(%q<hoe>.freeze, ["~> 3.15"])
+      s.add_runtime_dependency(%q<gli>, ["~> 2.13"])
+      s.add_development_dependency(%q<minitest>, ["~> 5.10"])
+      s.add_development_dependency(%q<rake>, ["< 12.0", ">= 10.0"])
+      s.add_development_dependency(%q<rdoc>, ["~> 4.2"])
+      s.add_development_dependency(%q<hoe-doofus>, ["~> 1.0"])
+      s.add_development_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
+      s.add_development_dependency(%q<hoe-git>, ["~> 1.5"])
+      s.add_development_dependency(%q<hoe-travis>, ["~> 1.2"])
+      s.add_development_dependency(%q<minitest-autotest>, ["~> 1.0"])
+      s.add_development_dependency(%q<minitest-bisect>, ["~> 1.2"])
+      s.add_development_dependency(%q<minitest-bonus-assertions>, ["~> 2.0"])
+      s.add_development_dependency(%q<minitest-focus>, ["~> 1.1"])
+      s.add_development_dependency(%q<minitest-moar>, ["~> 0.0"])
+      s.add_development_dependency(%q<minitest-pretty_diff>, ["~> 0.1"])
+      s.add_development_dependency(%q<simplecov>, ["~> 0.7"])
+      s.add_development_dependency(%q<hoe>, ["~> 3.16"])
     else
-      s.add_dependency(%q<gli>.freeze, ["~> 2.13"])
-      s.add_dependency(%q<minitest>.freeze, ["~> 5.9"])
-      s.add_dependency(%q<rdoc>.freeze, ["~> 4.0"])
-      s.add_dependency(%q<rake>.freeze, [">= 10.0"])
-      s.add_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-      s.add_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-      s.add_dependency(%q<hoe-git>.freeze, ["~> 1.5"])
-      s.add_dependency(%q<hoe-travis>.freeze, ["~> 1.2"])
-      s.add_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-      s.add_dependency(%q<minitest-bisect>.freeze, ["~> 1.2"])
-      s.add_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 2.0"])
-      s.add_dependency(%q<minitest-focus>.freeze, ["~> 1.1"])
-      s.add_dependency(%q<minitest-moar>.freeze, ["~> 0.0"])
-      s.add_dependency(%q<minitest-pretty_diff>.freeze, ["~> 0.1"])
-      s.add_dependency(%q<simplecov>.freeze, ["~> 0.7"])
-      s.add_dependency(%q<hoe>.freeze, ["~> 3.15"])
+      s.add_dependency(%q<gli>, ["~> 2.13"])
+      s.add_dependency(%q<minitest>, ["~> 5.10"])
+      s.add_dependency(%q<rake>, ["< 12.0", ">= 10.0"])
+      s.add_dependency(%q<rdoc>, ["~> 4.2"])
+      s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])
+      s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
+      s.add_dependency(%q<hoe-git>, ["~> 1.5"])
+      s.add_dependency(%q<hoe-travis>, ["~> 1.2"])
+      s.add_dependency(%q<minitest-autotest>, ["~> 1.0"])
+      s.add_dependency(%q<minitest-bisect>, ["~> 1.2"])
+      s.add_dependency(%q<minitest-bonus-assertions>, ["~> 2.0"])
+      s.add_dependency(%q<minitest-focus>, ["~> 1.1"])
+      s.add_dependency(%q<minitest-moar>, ["~> 0.0"])
+      s.add_dependency(%q<minitest-pretty_diff>, ["~> 0.1"])
+      s.add_dependency(%q<simplecov>, ["~> 0.7"])
+      s.add_dependency(%q<hoe>, ["~> 3.16"])
     end
   else
-    s.add_dependency(%q<gli>.freeze, ["~> 2.13"])
-    s.add_dependency(%q<minitest>.freeze, ["~> 5.9"])
-    s.add_dependency(%q<rdoc>.freeze, ["~> 4.0"])
-    s.add_dependency(%q<rake>.freeze, [">= 10.0"])
-    s.add_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_dependency(%q<hoe-git>.freeze, ["~> 1.5"])
-    s.add_dependency(%q<hoe-travis>.freeze, ["~> 1.2"])
-    s.add_dependency(%q<minitest-autotest>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<minitest-bisect>.freeze, ["~> 1.2"])
-    s.add_dependency(%q<minitest-bonus-assertions>.freeze, ["~> 2.0"])
-    s.add_dependency(%q<minitest-focus>.freeze, ["~> 1.1"])
-    s.add_dependency(%q<minitest-moar>.freeze, ["~> 0.0"])
-    s.add_dependency(%q<minitest-pretty_diff>.freeze, ["~> 0.1"])
-    s.add_dependency(%q<simplecov>.freeze, ["~> 0.7"])
-    s.add_dependency(%q<hoe>.freeze, ["~> 3.15"])
+    s.add_dependency(%q<gli>, ["~> 2.13"])
+    s.add_dependency(%q<minitest>, ["~> 5.10"])
+    s.add_dependency(%q<rake>, ["< 12.0", ">= 10.0"])
+    s.add_dependency(%q<rdoc>, ["~> 4.2"])
+    s.add_dependency(%q<hoe-doofus>, ["~> 1.0"])
+    s.add_dependency(%q<hoe-gemspec2>, ["~> 1.1"])
+    s.add_dependency(%q<hoe-git>, ["~> 1.5"])
+    s.add_dependency(%q<hoe-travis>, ["~> 1.2"])
+    s.add_dependency(%q<minitest-autotest>, ["~> 1.0"])
+    s.add_dependency(%q<minitest-bisect>, ["~> 1.2"])
+    s.add_dependency(%q<minitest-bonus-assertions>, ["~> 2.0"])
+    s.add_dependency(%q<minitest-focus>, ["~> 1.1"])
+    s.add_dependency(%q<minitest-moar>, ["~> 0.0"])
+    s.add_dependency(%q<minitest-pretty_diff>, ["~> 0.1"])
+    s.add_dependency(%q<simplecov>, ["~> 0.7"])
+    s.add_dependency(%q<hoe>, ["~> 3.16"])
   end
 end

--- a/lib/cartage/commands/info.rb
+++ b/lib/cartage/commands/info.rb
@@ -48,7 +48,7 @@ that just provide commands are not reported as plugins.
           puts <<-plugins
 Active Plug-ins:
 
-#{plugs.join("\n")}
+#{plugs.sort.join("\n")}
           plugins
         end
       end

--- a/lib/cartage/plugin.rb
+++ b/lib/cartage/plugin.rb
@@ -31,7 +31,7 @@ class Cartage
       # The version of the plug-in.
       def version
         if const_defined?(:VERSION, false)
-          VERSION
+          self::VERSION
         else
           Cartage::VERSION
         end
@@ -46,10 +46,13 @@ class Cartage
       # A utility method that will find all Cartage plug-ins and load them. A
       # Cartage plug-in is found in the Gems as <tt>cartage/plugins/*.rb</tt>
       # and descends from Cartage::Plugin.
-      def load #:nodoc:
+      def load(rescan: false) #:nodoc:
         @found ||= {}
         @loaded ||= {}
-        @files ||= Gem.find_files('cartage/plugins/*.rb')
+
+        if @files.nil? || rescan
+          @files = Gem.find_files('cartage/plugins/*.rb')
+        end
 
         @files.reverse_each do |path|
           name = File.basename(path, '.rb').to_sym


### PR DESCRIPTION
*   Cartage 2.1 now knows how to load plug-ins relative to the project root
    path. If you have a plug-in that you aren’t ready to release as a gem, just
    put it in your project as `<ROOT_PATH>/lib/cartage/plugins/foo.rb`; Cartage
    will find it automatically. This feature does not work with command
    extensions.

*   The hidden command, `cartage info plugins`, will now correctly report
    plug-in versions.